### PR TITLE
fix(devops): update ESLint config to allow ES6 modules

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,53 @@
+---
+engines:
+  eslint:
+    enabled: true
+    exclude_paths:
+      - "node_modules/**"
+      - "**/node_modules/**"
+      - "dist/**"
+      - "**/dist/**"
+      - "coverage/**"
+      - "**/coverage/**"
+    patterns:
+      # Disable rules that forbid ES6 modules and modern syntax
+      - id: "ESLint8_es-x_no-modules"
+        enabled: false
+      - id: "ESLint8_es-x_no-spread-elements"
+        enabled: false
+      - id: "ESLint8_es-x_no-arrow-functions"
+        enabled: false
+      - id: "ESLint8_es-x_no-block-scoped-variables"
+        enabled: false
+      - id: "ESLint8_es-x_no-array-prototype-foreach"
+        enabled: false
+      - id: "ESLint8_es-x_no-trailing-commas"
+        enabled: false
+      # Allow modern import/export syntax
+      - id: "ESLint8_import_no-unresolved"
+        enabled: false
+      - id: "ESLint8_import_named"
+        enabled: false
+      - id: "ESLint8_n_no-unpublished-import"
+        enabled: false
+      # Allow spell checker to be more lenient with technical terms
+      - id: "ESLint8_spellcheck_spell-checker"
+        enabled: false
+
+  stylelint:
+    enabled: true
+    exclude_paths:
+      - "node_modules/**"
+      - "**/node_modules/**"
+      - "dist/**"
+      - "**/dist/**"
+
+exclude_paths:
+  - "node_modules/**"
+  - "**/node_modules/**"
+  - "dist/**"
+  - "**/dist/**"
+  - "coverage/**"
+  - "**/coverage/**"
+  - "scripts/mongo-init.js"  # MongoDB script with specific environment
+  - "github-actions-coverage.test.js"  # Test file with specific requirements

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,53 +1,31 @@
 ---
+# Codacy configuration to support ES6 modules while maintaining code quality
 engines:
   eslint:
     enabled: true
-    exclude_paths:
-      - "node_modules/**"
-      - "**/node_modules/**"
-      - "dist/**"
-      - "**/dist/**"
-      - "coverage/**"
-      - "**/coverage/**"
     patterns:
-      # Disable rules that forbid ES6 modules and modern syntax
+      # CRITICAL: Disable ES6 syntax prohibition rules to resolve issue #93
+      # These rules incorrectly flag modern JavaScript as forbidden despite package.json "type": "module"
       - id: "ESLint8_es-x_no-modules"
         enabled: false
-      - id: "ESLint8_es-x_no-spread-elements"
+      - id: "ESLint8_es-x_no-spread-elements" 
         enabled: false
       - id: "ESLint8_es-x_no-arrow-functions"
         enabled: false
       - id: "ESLint8_es-x_no-block-scoped-variables"
         enabled: false
-      - id: "ESLint8_es-x_no-array-prototype-foreach"
-        enabled: false
       - id: "ESLint8_es-x_no-trailing-commas"
         enabled: false
-      # Allow modern import/export syntax
-      - id: "ESLint8_import_no-unresolved"
-        enabled: false
-      - id: "ESLint8_import_named"
-        enabled: false
-      - id: "ESLint8_n_no-unpublished-import"
-        enabled: false
-      # Allow spell checker to be more lenient with technical terms
+      # Disable spell checking for technical terms (tseslint, vitest, etc.)
       - id: "ESLint8_spellcheck_spell-checker"
         enabled: false
 
-  stylelint:
-    enabled: true
-    exclude_paths:
-      - "node_modules/**"
-      - "**/node_modules/**"
-      - "dist/**"
-      - "**/dist/**"
-
 exclude_paths:
   - "node_modules/**"
-  - "**/node_modules/**"
+  - "**/node_modules/**" 
   - "dist/**"
   - "**/dist/**"
   - "coverage/**"
   - "**/coverage/**"
-  - "scripts/mongo-init.js"  # MongoDB script with specific environment
+  - "scripts/mongo-init.js"  # MongoDB script with environment-specific globals
   - "github-actions-coverage.test.js"  # Test file with specific requirements

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,8 @@ export default tseslint.config(
   {
     files: ['**/*.{js,ts,tsx}'],
     languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
       globals: {
         process: 'readonly',
         console: 'readonly'

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -8,6 +8,10 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,

--- a/packages/server/eslint.config.js
+++ b/packages/server/eslint.config.js
@@ -6,6 +6,10 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/explicit-function-return-type': 'off',

--- a/packages/shared/eslint.config.js
+++ b/packages/shared/eslint.config.js
@@ -6,6 +6,10 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     files: ['src/**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
## Summary

Updates ESLint configuration across all packages to properly support ES6 modules and resolves Codacy compatibility issues.

## Changes Made

- ✅ Added explicit `ecmaVersion: 'latest'` and `sourceType: 'module'` to all ESLint configs
- ✅ Created `.codacy.yml` configuration to disable problematic ES6 prohibition rules
- ✅ Disabled `es-x/no-modules`, `es-x/no-spread-elements`, `es-x/no-arrow-functions` in Codacy
- ✅ Updated root, server, client, and shared package ESLint configurations
- ✅ Verified all linting and type checking passes locally
- ✅ Confirmed ES6 import/export syntax works correctly

## Problem Resolved

Codacy was flagging ES6 module syntax as forbidden due to compatibility rules that were preventing the use of:
- `import`/`export` statements
- Arrow functions
- Spread operators
- Block-scoped variables (`const`/`let`)

This conflicted with the project's ES module architecture as defined in `package.json` files with `"type": "module"`.

## Testing

- ✅ All ESLint rules pass locally
- ✅ TypeScript compilation succeeds
- ✅ Markdownlint passes
- ✅ Codacy local analysis shows ES6 module errors resolved
- ✅ All workspace packages lint successfully

## Type of Change

- [x] Bug fix (fixes Codacy ESLint configuration conflict)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

CLOSES: #93

🤖 Generated with [Claude Code](https://claude.ai/code)