### PR TITLE
fix(devops): resolve detached HEAD error in GitHub Action lint workflow

### DIFF
--- a/.github/workflows/lint-auto-fix.yml
+++ b/.github/workflows/lint-auto-fix.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,4 +52,4 @@ jobs:
           git config --local user.name "GitHub Action"
           git add .
           git commit -m "GitHub action corrected formatting"
-          git push
+          git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
## Summary

This PR fixes the detached HEAD error in the GitHub Action lint-auto-fix workflow that was preventing the action from committing changes back to PR branches.

## Changes Made

- Added `ref: ${{ github.head_ref }}` to the checkout action to ensure we check out the actual PR branch instead of a detached HEAD state
- Updated the push command to explicitly target the PR branch with `git push origin HEAD:${{ github.head_ref }}`

## Problem Solved

The previous workflow would fail when trying to commit and push changes because it was operating in a detached HEAD state. This is a common issue with GitHub Actions when working with pull requests.

## Testing

This PR itself will test the fix - if the auto-fix action runs successfully and can commit changes, then the fix is working correctly.

CLOSES: #96

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>